### PR TITLE
[디자인 시스템] functions

### DIFF
--- a/packages/design-system/src/functions/_colors.scss
+++ b/packages/design-system/src/functions/_colors.scss
@@ -1,0 +1,70 @@
+@use "sass:color";
+@use "sass:map";
+@use "sass:math";
+@use "../base/" as *;
+
+/// $colors또는 Sass map에서 컬러 값을 리턴
+/// @param {string} $type : base, primary, secondary 등등 컬러 그룹 타입
+/// @param {string} $key : 컬러의 이름
+/// @param {boolean} $only-color : true일 경우 컬러 값만 가져오기
+/// @return {$type} : $map : 컬러를 가져올 map
+@function color($type: "default", $key, $only-color: false, $map: $colors) {
+  @if not map.has-key($map, $type, $key) {
+    @error "The #{$key} key name doesn't exist under #{$type} at the specified map (default: $colors).";
+  }
+
+  @if not map.get($map, $type, $key) {
+    @return null;
+  }
+
+  @if $only-color {
+    @return map.get($map, $type, $key);
+  }
+
+  @if map.get($settings, color-fallback) {
+    @return var(
+      --#{$internal-prefix}#{$type}-color-#{$key},
+      #{map.get($map, $type, $key)}
+    );
+  }
+
+  @return var(--#{$internal-prefix}#{$type}-color-#{$key});
+}
+
+/// $colors 컬러 map으로부터 아무 / 하나의 컬러 값만 반환
+/// @param {string} $type : 컬러 그룹의 타입 (base, primary, secondary 등등)
+/// @param {string} $key : 컬러의 키 이름
+/// @param {map} $map : 컬러를 가져올 map
+/// @return {color}: 컬러 값
+@function color-value($type: "default", $key, $map: $colors) {
+  @if not map.has-key($map, $type, $key) {
+    @error "The #{$key} key name doesn't exist under #{$type} at the specified map (default: $colors).";
+  }
+
+  @if not map.get($map, $type, $key) {
+    @return null;
+  }
+
+  @return map.get($map, $type, $key);
+}
+
+/// 흑/백 색 대조 리턴 (WCAG 기준)
+/// 참고 출처 : https://codepen.io/davidhalford/pen/ALrbEP
+/// @param {color} $color : 대조 바탕이 될 컬러
+/// @return {color} : 대조 컬러
+@function color-contrast($color) {
+  $color-brightness: math.round(
+    (color.red($color) * 299) + (color.green($color) * 587) +
+      math.div(color.blue($color) * 114, 1000)
+  );
+  $light-color: math.round(
+    (color.red(#ffffff) * 299) + (color.green(#ffffff) * 587) +
+      math.div(color.blue(#ffffff) * 114, 1000)
+  );
+
+  @if math.abs($color-brightness) < math.div($light-color, 2) {
+    @return hsl(0 0% 100%);
+  } @else {
+    @return hsl(0 100% 0%);
+  }
+}

--- a/packages/design-system/src/functions/_shape.scss
+++ b/packages/design-system/src/functions/_shape.scss
@@ -1,0 +1,29 @@
+@use "sass:map";
+@use "sass:meta";
+@use "sass:math";
+@use "../base/" as *;
+
+/// 도형 이름과 그룹에 해당 도형 값 리턴
+/// @param {string} $size : 도형의 크기
+/// @return {number} : 도형의 값
+@function shape($size: default) {
+  $fetched-shape: map.get($config-shape, $size);
+
+  @if meta.type-of($size) == number {
+    @if $size == 0 {
+      @return 0;
+    }
+
+    @if math.is-unitless($size) {
+      @return $size * 1px;
+    } @else {
+      @return $size;
+    }
+  }
+
+  @if meta.type-of($fetched-shape) {
+    @return $fetched-shape;
+  } @else {
+    @error "Shape `#{$size}` not found. Available shapes: #{$config-shape}";
+  }
+}

--- a/packages/design-system/src/functions/_space.scss
+++ b/packages/design-system/src/functions/_space.scss
@@ -1,0 +1,28 @@
+@use "sass:map";
+@use "sass:meta";
+@use "sass:math";
+@use "../base/" as *;
+
+/// 주어진 space 값에 해당되는 간격을 픽셀로 리턴
+/// @param {string} $space : 필요한 간격
+/// @param {map} $map : 필요한 간격을 찾을 map
+/// @return {number} : $map에서 필요한 간격을 px 단위로 리턴
+@function space($space: default, $map: $config-space) {
+  @if map.has-key($map, $space) {
+    @return map.get($map, $space);
+  }
+
+  @if meta.type-of($space) == number {
+    @if $space == 0 {
+      @return 0;
+    }
+
+    @if math.is-unitless($space) {
+      @return $space * 1px;
+    } @else {
+      @return $space;
+    }
+  } @else {
+    @error "Spacing variant `#{$space}` not found. Available variants: #{$map}";
+  }
+}

--- a/packages/design-system/src/functions/_typography.scss
+++ b/packages/design-system/src/functions/_typography.scss
@@ -1,0 +1,101 @@
+@use "sass:map";
+@use "sass:meta";
+@use "sass:math";
+@use "../base/" as *;
+
+/// 정의했던 font family로부터 폰트 반환
+/// @param {string} $family : font family
+/// @return {string} : 정의했던 font family
+@function font-family($family: default) {
+  $fetched-font-family: map.get($config-font-stack, $family);
+
+  @if meta.type-of($fetched-font-family) {
+    @return $fetched-font-family;
+  } @else {
+    @error "Font family `#{$family}` not found. Available font families: #{$config-font-stack}";
+  }
+}
+
+/// 주어진 범위의 폰트 크기 반환
+/// @param {number} $range : 폰트 크기
+/// @return {number} : 해당 폰트 스타일에 존재하는 폰트 크기
+@function font-size($range) {
+  $fetched-font-size: map.get($config-font-size, $range);
+
+  @if meta.type-of($range) == number {
+    @if $range == 0 {
+      @return 0;
+    }
+
+    @if math.is-unitless($range) {
+      @return $range * 1px;
+    } @else {
+      @return $range;
+    }
+  }
+
+  @if meta.type-of($fetched-font-size) {
+    @return $fetched-font-size;
+  } @else {
+    @error "Font size range `#{$range}` not found. Available font sizes: #{$config-font-size}";
+  }
+}
+
+/// 주어진 폰트 두께에 해당되는 font weight 반환
+/// @param {string} $weight - Font weight.
+/// @return {number} : 정의했던 font weight
+@function font-weight($weight: regular) {
+  $fetched-font-weight: map.get($config-font-weight, $weight);
+
+  @if meta.type-of($weight) == number {
+    @return $weight;
+  }
+
+  @if meta.type-of($fetched-font-weight) {
+    @return $fetched-font-weight;
+  } @else {
+    @error "Font weight `#{$weight}` not found. Available font weights: #{$config-font-weight}";
+  }
+}
+
+/// 주어진 범위의 line height 반환
+/// @param {number} $range : 폰트 스타일 범위
+/// @return {number} : 정의했던 line-height
+@function line-height($range: normal) {
+  $fetched-line-height: map.get($config-line-height, $range);
+
+  @if meta.type-of($range) == number {
+    @return $range;
+  }
+
+  @if meta.type-of($fetched-line-height) {
+    @return $fetched-line-height;
+  } @else {
+    @error "Line height `#{$range}` not found. Available line heights: #{$config-line-height}";
+  }
+}
+
+/// 정의했던 letter spacing에 해당 간격 반환
+/// @param {string} $letter-spacing : 문자 간격
+/// @return {number} : letter-spacing
+@function letter-spacing($letter-spacing: 0) {
+  $fetched-letter-spacing: map.get($config-letter-spacing, $letter-spacing);
+
+  @if meta.type-of($letter-spacing) == number {
+    @if $letter-spacing == 0 {
+      @return 0;
+    }
+
+    @if math.is-unitless($letter-spacing) {
+      @return $letter-spacing * 1px;
+    } @else {
+      @return $letter-spacing;
+    }
+  }
+
+  @if meta.type-of($fetched-letter-spacing) {
+    @return $fetched-letter-spacing;
+  } @else {
+    @error "letter spacing `#{$letter-spacing}` not found. Available letter spacings: #{$config-letter-spacing}";
+  }
+}

--- a/packages/design-system/src/functions/_units.scss
+++ b/packages/design-system/src/functions/_units.scss
@@ -1,0 +1,66 @@
+@use "sass:math";
+@use "sass:meta";
+@use "typography" as *;
+
+/// css 값의 단위 제거하여
+/// @param {number} $value : 단위를 거할 값
+/// @return {number} : 단위를 제거한 값
+@function strip-unit($value) {
+  @if meta.type-of($value) != "number" {
+    @error "Invalid `#{meta.type-of($value)}` type. Choose a number type instead.";
+  } @else if meta.type-of($value) == "number" and not math.is-unitless($value) {
+    @return math.div($value, ($value * 0 + 1));
+  }
+
+  @return $value;
+}
+
+/// 픽셀 값으로부터 rem값 반환
+/// @param {number} $value : 픽셀 단위의 값
+/// @return {number} : rem으로 변환한 값
+@function remify($value) {
+  $unit: math.unit($value);
+  $default-font-size: font-size("default");
+  $stripped-default: strip-unit($default-font-size);
+
+  @if $value == 0 {
+    @return 0;
+  }
+
+  @if math.is-unitless($value) {
+    @return math.div($value, $stripped-default) * 1rem;
+  } @else if $unit == "rem" {
+    @return $value;
+  } @else if $unit == "px" {
+    @return math.div($value, $default-font-size) * 1rem;
+  } @else {
+    @error "Value must be in px, rem or just a number.";
+  }
+}
+
+/// 픽셀값을 em으로 변환하여 반환. font-size 변경이 없는 요소만 적용가능
+/// @param {number} $value : 변환할 픽셀 값
+/// @return {number} : em으로 변환한 값
+@function em($value) {
+  $unit: math.unit($value);
+  $default-font-size: font-size("default");
+  $stripped-default: strip-unit($default-font-size);
+
+  @if $value == 0 {
+    @return 0;
+  }
+
+  @if math.is-unitless($value) {
+    @return math.div($value, $stripped-default) * 1em;
+  }
+
+  @if $unit == "em" {
+    @return $value;
+  }
+
+  @if $unit == "px" {
+    @return math.div($value, $default-font-size) * 1em;
+  } @else {
+    @error "Value must be in px, em or just a number.";
+  }
+}

--- a/packages/design-system/src/functions/_z-index.scss
+++ b/packages/design-system/src/functions/_z-index.scss
@@ -1,0 +1,21 @@
+@use "sass:map";
+@use "sass:meta";
+@use "../base/" as *;
+
+/// config 맵으로부터 z-index 값 반환
+/// @param {string} $layer : `$z-indexes` 맵에서의 값
+/// @return {number} : z-index 값
+/// @throws {Error} : 없는 layer 옵션일 경우
+@function z($layer: default) {
+  $fetched-z-index: map.get($config-z-index, $layer);
+
+  @if meta.type-of($layer) == number {
+    @return $layer;
+  }
+
+  @if meta.type-of($fetched-z-index) {
+    @return $fetched-z-index;
+  } @else {
+    @error "Z-index with such layer `#{$layer}` not found. Available z-indexes: #{$config-z-index}";
+  }
+}


### PR DESCRIPTION
# PULL REQUEST TEMPLATE

@appear 

## PR 설명

디자인 시스템은 스타일을 규정한 `base`와 이를 활용한 `mixin`와`function` 폴더로 구성됩니다.

해당 pr은 `base`에 정의한 스타일들을 이용해 스타일  값을 반환해주는  `function`들을 추가했습니다.

|커밋|파일|내용|함수|
|:---:|:---|:---|:-----|
|[b318e7f](https://github.com/f-lab-edu/Tripie/pull/26/commits/b318e7f4f10e9956b34680556a0ad29a65777201)|`_shape.scss`| 도형 관련 함수들 |`shape($size)`: `$size`에 해당되는 도형 모양 리턴 |
|[f23d815](https://github.com/f-lab-edu/Tripie/pull/26/commits/f23d8158bc3fe73a3fc0c3ae1f0198c0efd8ea1a)|`_color.scss`| 컬러와 관련된 함수들|`color($type, $only-color, $map)`: 컬러 그룹 타입을 정의한 `$type`에 있는 `$key` 컬러 값 리턴, `$only-color` 설정 시 컬러 값만 반환 <br/>`color-value($type, $key, $map)`:  컬러 그룹 타입`$type`에 해당되는 `$key`이름의 맵에서 컬러 값 리턴<br/> `color-contrast($color)`: `$color`값에 대비되는 컬러 값 리턴|
|[3b94335](https://github.com/f-lab-edu/Tripie/pull/26/commits/3b94335b02f4b7c21b38cdb43c9532a37b0a0374)|`_space.scss`| 간격와 관련된 함수들|`space($space, $map)`: `$map` 간격 맵에 있는 간격 값 리턴 |
|[9c6b4ca](https://github.com/f-lab-edu/Tripie/pull/26/commits/9c6b4ca2fca30bdf2a0f0c3de7e18475a1633a92)|`_z-index.scss`| z-index 관련 함수들| `z($layer)`: `$layer` 맵에 있는 z-index 값 리턴 |
|[7a1c9fd](https://github.com/f-lab-edu/Tripie/pull/26/commits/7a1c9fdbf450a975274ade416661efb6bce56791)|`_typography.scss`| typography 관련 함수들| `font-family($family)`: `$family` 맵에 있는 font-family 값 리턴 <br/> `font-size($range)`: `$range`에 해당하는 크기의 폰트가 정의해뒀던 폰트 패밀리에 있는  폰트 크기 값 반환 <br/> `font-weight($weight)`: `$weight`에 해당하는 폰트 두께의 폰트 두께 값 리턴 <br/> `line-height($range)`: `${weight}`에 해당하는 line 높이 반환 <br/> `letter-spacing($letter-spacing)`: 정의해뒀던 letter-spacing에 글자 간 간격 리턴|
|[7a1c9fd](https://github.com/f-lab-edu/Tripie/pull/26/commits/7a1c9fdbf450a975274ade416661efb6bce56791)|`_utils.scss`| 단위 관련 함수들| `strip-unit($value)`: `$value`로 값 단위 제거 <br/> `remify($value)`: `$value`픽셀 값을 rem으로 변환 <br/> `em($value)`: 픽셀 단위를 제거한 `$value`를 em으로 변환|