### PR TITLE
[💅 design system] 이미지 컴포넌트 생성

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -14,6 +14,26 @@ const nextConfig = {
   sassOptions: {
     includePaths: [path.join(__dirname, "styles")],
   },
+  images: {
+    dangerouslyAllowSVG: true,
+    contentDispositionType: "attachment",
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "placehold.co",
+        port: "",
+        pathname: "/**",
+      },
+
+      {
+        protocol: "https",
+        hostname: " /eu.ui-avatars.com/api",
+        port: "",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -1,5 +1,6 @@
 export { default as Body } from "./body";
 export { default as Drawer } from "./drawer";
+export { default as Image } from "./media/image";
 export { default as MyButton } from "./myButton";
 export { default as Headers } from "./typography";
 export { default as Text } from "./typography/text";

--- a/packages/design-system/src/components/media/image/_image.module.scss
+++ b/packages/design-system/src/components/media/image/_image.module.scss
@@ -1,0 +1,30 @@
+@use "../../../functions/" as *;
+@use "sass:map";
+
+$size-map: (
+  l: space(60),
+  m: space(40),
+  sm: space(36),
+);
+
+@mixin size($size: "m", $value) {
+  width: $value;
+  height: $value;
+}
+
+@each $key, $value in $size-map {
+  .profile.#{$key} {
+    @include size($key, $value);
+  }
+}
+
+.image {
+  position: relative !important;
+}
+.default {
+  border-radius: shape(sm);
+}
+.profile {
+  border-radius: shape(circle);
+  object-fit: cover;
+}

--- a/packages/design-system/src/components/media/image/_image.stories.tsx
+++ b/packages/design-system/src/components/media/image/_image.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useEffect } from "react";
+import { useAppTheme } from "../../../hooks";
+import Image from "./_image";
+
+const meta: Meta<typeof Image> = {
+  title: "tripie-ui/Image",
+  component: Image,
+  tags: ["autodocs"],
+  decorators: [
+    (story, context) => {
+      const { mode, setMode } = useAppTheme();
+      const selectedTheme = context.globals.theme || mode;
+
+      useEffect(() => {
+        setMode(selectedTheme);
+      }, [selectedTheme]);
+
+      return <div className={`${context.globals.theme}`}>{story()}</div>;
+    },
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: "Image",
+  args: {
+    src: "https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/b1685ba5-797a-40f2-98a5-c5480e32742d.jpeg",
+    alt: "https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/b1685ba5-797a-40f2-98a5-c5480e32742d.jpeg",
+  },
+};
+
+export const NoImage: Story = {
+  name: "No Image",
+  args: {},
+};
+
+export const DefaultProfile: Story = {
+  name: "Default Profile",
+  args: {
+    variant: "profile",
+    src: "https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/b1685ba5-797a-40f2-98a5-c5480e32742d.jpeg",
+    alt: "https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/b1685ba5-797a-40f2-98a5-c5480e32742d.jpeg",
+  },
+};
+
+export const NoProfileImage: Story = {
+  name: "No Profile Image",
+  decorators: [
+    (story) => {
+      return story().type.Profile({ userName: "하나" });
+    },
+  ],
+};
+
+export const LargeProfile: Story = {
+  name: "Large Profile",
+  args: {
+    variant: "profile",
+    sizes: "l",
+    src: "https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/b1685ba5-797a-40f2-98a5-c5480e32742d.jpeg",
+    alt: "https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/b1685ba5-797a-40f2-98a5-c5480e32742d.jpeg",
+  },
+};
+
+export const SmallProfile: Story = {
+  name: "Small Profile",
+  args: {
+    variant: "profile",
+    sizes: "sm",
+    src: "https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/b1685ba5-797a-40f2-98a5-c5480e32742d.jpeg",
+    alt: "https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/b1685ba5-797a-40f2-98a5-c5480e32742d.jpeg",
+  },
+};

--- a/packages/design-system/src/components/media/image/_image.tsx
+++ b/packages/design-system/src/components/media/image/_image.tsx
@@ -1,0 +1,81 @@
+import classNames from "classnames/bind";
+import { StaticImport } from "next/dist/shared/lib/get-img-props";
+import { default as NextImage } from "next/image";
+import Style from "./_image.module.scss";
+
+const DEFAULT_IMAGE_SIZE_PX = 1024;
+const URLS = {
+  NO_IMAGE: "https://placehold.co/600x600?text=NO+IMAGE",
+  NO_PROFILE: "https://eu.ui-avatars.com/api/?name=&size=250",
+};
+
+export type ImageProps = {
+  width?: number;
+  height?: number;
+  src?: string | StaticImport;
+  variant?: "default" | "profile";
+  alt?: string | StaticImport;
+  sizes?: "l" | "m" | "sm";
+} & Omit<
+  React.ImgHTMLAttributes<HTMLImageElement>,
+  "width" | "height" | "sizes"
+>;
+
+const cx = classNames.bind(Style);
+
+const Image = ({
+  children,
+  className,
+  src = URLS.NO_IMAGE,
+  alt = "NO IMAGE",
+  width = DEFAULT_IMAGE_SIZE_PX,
+  height = DEFAULT_IMAGE_SIZE_PX,
+  variant,
+  sizes = "m",
+  ...props
+}: ImageProps) => {
+  return (
+    <NextImage
+      className={cx(
+        className,
+        variant,
+        variant == "profile" ? sizes : null,
+        "image"
+      )}
+      width={width}
+      src={src}
+      alt={alt}
+      height={height}
+      {...props}
+    />
+  );
+};
+
+export type ProfileProps = {
+  userName: string;
+} & ImageProps;
+
+const ProfileImage = ({
+  sizes,
+  src = URLS.NO_PROFILE,
+  userName = "",
+  ...props
+}: ProfileProps) => (
+  <Image
+    {...props}
+    variant="profile"
+    src={
+      src == URLS.NO_PROFILE
+        ? URLS.NO_PROFILE.replace(
+            "?name=&size=250",
+            `?name=${userName}&size=250`
+          )
+        : src
+    }
+    sizes={sizes}
+  />
+);
+
+Image.Profile = ProfileImage;
+
+export default Image;

--- a/packages/design-system/src/components/media/image/_image.tsx
+++ b/packages/design-system/src/components/media/image/_image.tsx
@@ -30,7 +30,7 @@ const Image = ({
   alt = "NO IMAGE",
   width = DEFAULT_IMAGE_SIZE_PX,
   height = DEFAULT_IMAGE_SIZE_PX,
-  variant,
+  variant = "default",
   sizes = "m",
   ...props
 }: ImageProps) => {

--- a/packages/design-system/src/components/media/image/index.ts
+++ b/packages/design-system/src/components/media/image/index.ts
@@ -1,0 +1,2 @@
+export * from "./_image";
+export { default } from "./_image";


### PR DESCRIPTION
# PULL REQUEST TEMPLATE

## PR 설명

@appear 

#54 일반 이미지와 프로필 이미지가 포함된 이미지 컴포넌트입니당.
#55 의 이미지 태그를 해당 컴포넌트로 대체 예정입니다.

## 스크린샷 & URL

- 기본 이미지 
<img width="598" alt="image" src="https://github.com/user-attachments/assets/3c683d26-7145-4872-9977-2e7d205d9408">

- 기본 이미지, 이미지 url이 없을 경우
<img width="598" alt="image" src="https://github.com/user-attachments/assets/484b09e3-019b-41c3-a14f-00350a14d910">

- Image.Profile

<img width="668" alt="image" src="https://github.com/user-attachments/assets/a437cead-a28a-4abb-b14e-123b45eac9ab">

